### PR TITLE
Fix bug

### DIFF
--- a/SFRainWashesFilth/About/About.xml
+++ b/SFRainWashesFilth/About/About.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-	<ModMetaData>
-		<name>SF [v1.2] Rain Removes All Filth</name>
-		 <packageId>Shotgunfrenzy.Rain.Removes.Filth</packageId>
-		<supportedVersions>
+<ModMetaData>
+	<name>SF [v1.2] Rain Removes All Filth</name>
+	<packageId>Shotgunfrenzy.Rain.Removes.Filth</packageId>
+	<supportedVersions>
 		<li>1.2</li>
 		<li>1.1</li>
-		</supportedVersions>
-		<author>Shotgunfrenzy</author>
-		<description>A simple patch that allows rain to remove filth such as dirt, sand and animal filth, Gives your vegeta-- I mean cleaner, a little bit less work when it's raining</description>
+	</supportedVersions>
+	<author>Shotgunfrenzy</author>
+	<description>A simple patch that allows rain to remove filth such as dirt, sand and animal filth, Gives your vegeta-- I mean cleaner, a little bit less work when it's raining</description>
 </ModMetaData>

--- a/SFRainWashesFilth/Patches/Patch.xml
+++ b/SFRainWashesFilth/Patches/Patch.xml
@@ -1,26 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-
 	<Operation Class="PatchOperationSequence">
-	<success>Always</success>
-	
-		<operations>
-		
+	<success>Always</success>	
+		<operations>		
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Filth_AnimalFilth"]/filth</xpath>
-			<value>
-			<rainWashes>true</rainWashes>
-			</value>
+				<xpath>/Defs/ThingDef[defName="Filth_AnimalFilth"]/filth</xpath>
+				<value>
+					<rainWashes>true</rainWashes>
+				</value>
 			</li>
-
-
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Filth_Sand"]/filth</xpath>
-			<value>
-			<rainWashes>true</rainWashes>
-			</value>
-			</li>
-		
+				<xpath>/Defs/ThingDef[defName="Filth_Sand"]/filth</xpath>
+				<value>
+					<rainWashes>true</rainWashes>
+				</value>
+			</li>		
 		</operations>
 	</Operation>	
 </Patch>

--- a/SFRainWashesFilth/Patches/Patch.xml
+++ b/SFRainWashesFilth/Patches/Patch.xml
@@ -7,13 +7,6 @@
 		<operations>
 		
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Filth_Dirt"]/filth</xpath>
-			<value>
-			<rainWashes>true</rainWashes>
-			</value>
-			</li>
-		
-			<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName="Filth_AnimalFilth"]/filth</xpath>
 			<value>
 			<rainWashes>true</rainWashes>


### PR DESCRIPTION
This mod was patching in a duplicate `<rainWashes>true</rainWashes>` tag into `Filth_Dirt`. I simply deleted this operation, fixing the error thrown on launch.

Note: this change may have been introduced since RimWorld 1.1 - if this causes errors for 1.1 users, you'll want to introduce mod versioning. I can link examples, if necessary.